### PR TITLE
Update Program.cs

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Drawing;
+using System.Globalization;
 
 namespace Rastermatic
 {
@@ -62,7 +63,7 @@ namespace Rastermatic
         <Part id=""2"" partType=""Label-1"" position=""0,0,0"" rotation=""270,0,0"" drag=""0,0,0,0,0,0"" materials=""0,1,2"" scale=""1,1,1"" partCollisionResponse=""Default"" calculateDrag=""false"">
            <Label.State designText = ""&lt";
            
-           OutputContent += string.Format(CultureInfo.CreateSpecificCulture("en-US"), ";mspace={0:F2}em&gt;&lt;line-height={1:F2}em&gt;", PixelSize, PixelSize);
+           OutputContent += string.Format(CultureInfo.InvariantCulture, ";mspace={0:F2}em&gt;&lt;line-height={1:F2}em&gt;", PixelSize, PixelSize);
 
                 BitmapSize = InputBitmap.Size;
                 Console.WriteLine($"Image resolution: {BitmapSize.Width}x{BitmapSize.Height}");
@@ -87,7 +88,7 @@ namespace Rastermatic
                         {
                             if (IsTransparentPrevious)
                             {
-                                OutputContent += string.Format(CultureInfo.CreateSpecificCulture("en-US"), "&lt;space={0:F3}em&gt;", PixelSize * TransparentCount);
+                                OutputContent += string.Format(CultureInfo.InvariantCulture, "&lt;space={0:F3}em&gt;", PixelSize * TransparentCount);
                                 TransparentCount = 0;
                             }
 

--- a/Program.cs
+++ b/Program.cs
@@ -60,7 +60,9 @@ namespace Rastermatic
     <Assembly>
       <Parts>
         <Part id=""2"" partType=""Label-1"" position=""0,0,0"" rotation=""270,0,0"" drag=""0,0,0,0,0,0"" materials=""0,1,2"" scale=""1,1,1"" partCollisionResponse=""Default"" calculateDrag=""false"">
-           <Label.State designText = ""&lt;mspace={PixelSize}em&gt;&lt;line-height={PixelSize}em&gt;";
+           <Label.State designText = ""&lt";
+           
+           OutputContent += string.Format(CultureInfo.CreateSpecificCulture("en-US"), ";mspace={0:F2}em&gt;&lt;line-height={1:F2}em&gt;", PixelSize, PixelSize);
 
                 BitmapSize = InputBitmap.Size;
                 Console.WriteLine($"Image resolution: {BitmapSize.Width}x{BitmapSize.Height}");
@@ -85,7 +87,7 @@ namespace Rastermatic
                         {
                             if (IsTransparentPrevious)
                             {
-                                OutputContent += $"&lt;space={PixelSize * TransparentCount:F3}em&gt;";
+                                OutputContent += string.Format(CultureInfo.CreateSpecificCulture("en-US"), "&lt;space={0:F3}em&gt;", PixelSize * TransparentCount);
                                 TransparentCount = 0;
                             }
 


### PR DESCRIPTION
On none US/EN machines, delimiter for numeric values is ","  -  seems that this doesn´t work (image with artifacts in SP). Maybe there is a smarter way to force a "." delimiter.